### PR TITLE
Best maps archive

### DIFF
--- a/Accessories.h
+++ b/Accessories.h
@@ -13,6 +13,17 @@
 #define MAX_WALL 12
 #define MAX_DONUT 16
 
+typedef struct bestmaps
+{
+    int mapnum;
+    int beacontype;
+    int maxbeacon;
+    int score;
+    int mapID;
+    int map[MAX_ROW][MAX_COL];
+    bestmaps *next;
+} bestmaps;
+
 void SetWhichToCheck (int maps, int options);
 int  MakeNumber (char *sData);
 bool LoadOperatingMode (int *maps, int *options, int *beacons, int *beacontype);
@@ -27,3 +38,11 @@ void CalcWlValues (int *hwlhitby, int *hwlavail, int *vwlhitby, int *vwlavail, i
 void CalcDtValues (int *dthitby, int *dtavail, int x, int y);
 void Shuffle ();
 void CopyMap (int sourcemap[MAX_ROW][MAX_COL], int destmap[MAX_ROW][MAX_COL]);
+int  CalculateMixedBeacons (int options, int beacons, int beacontype);
+bool DebugTestGrounds ();
+void LoadBestMaps ();
+void SaveBestMaps ();
+int BeaconDisp2Num (char c);
+char BeaconNum2Disp (int i);
+void Cleanup ();
+bool NewBestMap (int map, int beacontype, int beacons);

--- a/Alchemy.cpp
+++ b/Alchemy.cpp
@@ -23,6 +23,7 @@ int kny[8];
 int arx[71];
 int ary[71];
 int beaconval[3][5];
+int beaconxref[20];
 int forcetype;
 int forcecountmin;
 int forcecountmax;
@@ -39,6 +40,10 @@ int iBestVal;
 bool bDebug = false;
 HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 int beaconcolor = 15;
+bestmaps *maplist = 0;
+int iTotalMaps = 0;
+
+void WriteOneMap (ofstream& Data, int mapnum, int beacontype, int score, int map[MAX_ROW][MAX_COL], int beacons);
 
 int main(int argc, char* argv[])
 {
@@ -84,10 +89,10 @@ int main(int argc, char* argv[])
             beacons = 0;
         }
 
-        printf ("Which beacon type? 0=speed, 1=production, 2=efficiency\n");
+        printf ("Which beacon type? 0=speed, 1=production, 2=efficiency, 3=prod/eff mix\n");
         cin >> beacontype;
 
-        if ( (beacontype < 1) || (beacontype > 2) )
+        if ( (beacontype < 1) || (beacontype > 3) )
         {
             beacontype = 0;
         }
@@ -109,9 +114,17 @@ int main(int argc, char* argv[])
         }
         forcecountmax = forcecountmin; /* variable force count range only via input file. */
     }
+
+    if (bDebug)
+    {
+        if (!DebugTestGrounds () )
+        {
+            return 0;
+        }
+    }
     SetWhichToCheck (maps, options);
     InitBeacons ();
-    beaconcolor = 9;
+    beaconcolor = 11;
 
     if (beacontype == 1)
         beaconcolor = 5;
@@ -125,12 +138,27 @@ int main(int argc, char* argv[])
         {
             cout << "Try #" << i + 1;
         }
-        CalculateBestBeacons (options, beacons, beacontype);
+
+        if (beacontype != 3)
+        {
+            CalculateBestBeacons (options, beacons, beacontype);
+        }
+        else
+        {
+            CalculateMixedBeacons (options, beacons, beacontype);
+        }
     }
 
     CopyMap (bestmap, workmap);
     mapfinalvalue = iBestVal;
     DisplayResults (maps, options, beacons, beacontype);
+
+    if (NewBestMap (maps, beacontype, beacons) )
+    {
+        SaveBestMaps ();
+    }
+
+    Cleanup ();
 
     return 0;
 }
@@ -169,7 +197,7 @@ bool LoadOperatingMode (int *maps, int *options, int *beacons, int *beacontype)
 
         *beacontype = MakeNumber (sData);
 
-        if ( (*beacontype != 1) && (*beacontype != 2) )
+        if ( (*beacontype < 1) || (*beacontype > 3) )
             *beacontype = 0;
 
         Data >> sData;
@@ -232,119 +260,6 @@ bool LoadOperatingMode (int *maps, int *options, int *beacons, int *beacontype)
             bDebug = true;
 
     return bRetVal;
-}
-
-int MakeNumber (char *sData)
-{
-    int x = 0, iRetVal =0;
-
-    while (    (sData[x] >= '0')
-            && (sData[x] <= '9')
-          )
-    {
-        iRetVal += sData[x] - 48;
-        iRetVal *= 10;
-        x++;
-
-        if (iRetVal > 1000000000)
-        {
-            sData[0] = 0;
-            x = 0;
-            iRetVal = 0;
-        }
-    }
-    iRetVal /= 10;
-
-    return iRetVal;
-}
-
-/* This originally was just to load the map. It now includes other setup functionality as well. */
-void SetWhichToCheck (int maps, int options)
-{
-    char sData[360] = {0},
-         sFile[80];
-    bool bRetVal = false;
-    int iVal = 0, x = 0, y = 0;
-
-    sprintf (sFile, ".\\tutorial.txt");
-
-    if (maps == 2)
-    {
-        sprintf (sFile, ".\\flesh.txt");
-    }
-
-    if (maps == 3)
-    {
-        sprintf (sFile, ".\\tronne.txt");
-    }
-
-    if (maps == 4)
-    {
-        sprintf (sFile, ".\\candyland.txt");
-    }
-
-    ifstream Data(sFile);
-
-    Data >> sData;
-
-    for (x = 0; x < 17; x++)
-    {
-        for (y = 0; y < 20; y++)
-        {
-            if (sData[y] == '1') // 1 = open to place
-            {
-                basemap[x][y] = 1;
-            }
-            else if(sData[y] == '2') // 2 = usable, but currently blocked
-            {
-                basemap[x][y] = 2;
-            }
-            else
-            {
-                basemap[x][y] = 0; // 0 = unusable square
-            }
-        }
-        Data >> sData;
-    }
-
-    for (x = 0; x < (MAX_ROW * MAX_COL); x++)
-    {
-        searchorder[x] = x;
-    }
-
-    for (x = 0; x < MAX_ROW; x++)
-    {
-        for (y = 0; y < MAX_COL; y++)
-        {
-            switch (basemap[x][y])
-            {
-                case 1:
-                {
-                    baseworkmap[x][y] = 0;
-                    break;
-                }
-                case 2:
-                {
-                    if (options == 1)
-                    {
-                        baseworkmap[x][y] = 0;
-                    }
-                    else
-                    {
-                        baseworkmap[x][y] = -1;
-                    }
-                    break;
-                }
-                default:
-                {
-                    baseworkmap[x][y] = -1;
-                    break;
-                }
-            }
-        }
-    } // initialize base working map,
-
-    return;
 }
 
 int  CalculateBestBeacons (int options, int beacons, int beacontype)
@@ -683,6 +598,16 @@ int  DisplayResults (int maps, int options, int beacons, int beacontype)
     int x, y;
     SetConsoleTextAttribute(hConsole, 15);
 
+    if (bDebug)
+    {
+        for (x = 0; x < 16; x++)
+        {
+            SetConsoleTextAttribute(hConsole, x);
+            cout << "This is just a test.\n";
+        }
+        SetConsoleTextAttribute(hConsole, 15);
+    }
+
     cout << "Calculated beacon placement for map: ";
 
     switch (maps)
@@ -760,7 +685,7 @@ int  DisplayResults (int maps, int options, int beacons, int beacontype)
     {
         case 0:
         {
-            SetConsoleTextAttribute(hConsole, 9);
+            SetConsoleTextAttribute(hConsole, 11);
             cout << "speed";
             break;
         }
@@ -1101,4 +1026,831 @@ void CopyMap (int sourcemap[MAX_ROW][MAX_COL], int destmap[MAX_ROW][MAX_COL])
     }
 }
 
+int  CalculateMixedBeacons (int options, int beacons, int beacontype)
+{
+    short shMap[MAX_ROW * MAX_COL][20] = { 0 };
+    int i, x, y, workx, worky, workval, workbeacon, currval;
+    int sqhitby, sqavail, knhitby, knavail, arlhitby, arlavail;
+    int arrhitby, arravail, aruhitby, aruavail, ardhitby, ardavail;
+    int hwlhitby, hwlavail, vwlhitby, vwlavail, dthitby, dtavail;
+
+    int tempval, currforcecount;
+    bool done = false;
+
+    Shuffle (); /* randomizes the searchorder. */
+    memcpy (workmap, baseworkmap, iTotalArea * sizeof (int) );
+
+    currforcecount = 0;
+
+    if (forcecountmax > 0)
+    {
+        currforcecount = forcecountmin + rand() % (forcecountmax - forcecountmin + 1);
+    }
+
+    while (!done)
+    {
+        workval = workx = worky = workbeacon = 0;
+        tempval = 0;
+        done = true;
+
+        for (i = 0; i < iTotalArea; i++)
+        {
+            x = searchorder[i] / MAX_COL;
+            y = searchorder[i] % MAX_COL;
+            currval = 0;
+
+            if (workmap[x][y] == 0)
+            {
+                sqhitby = sqavail = knhitby = knavail = arlhitby = arlavail = 0;
+                arrhitby = arravail = aruhitby = aruavail = ardhitby = ardavail = 0;
+                hwlhitby = hwlavail = vwlhitby = vwlavail = dthitby = dtavail = 0;
+
+                CalcSqValues (&sqhitby, &sqavail, x, y);
+
+                if (beacons > 0)
+                {
+                    CalcKnValues (&knhitby, &knavail, x, y);
+                }
+
+                if (beacons > 1)
+                {
+                    CalcArValues (&arrhitby, &arravail, &arlhitby, &arlavail,
+                                  &ardhitby, &ardavail, &aruhitby, &aruavail, x, y);
+                }
+
+                if (beacons > 2)
+                {
+                    CalcWlValues (&hwlhitby, &hwlavail, &vwlhitby, &vwlavail, x, y);
+                }
+
+                if (beacons > 3)
+                {
+                    CalcDtValues (&dthitby, &dtavail, x, y);
+                }
+
+                currval -= sqhitby * beaconval[beacontype][0 /*squares*/];
+                currval -= knhitby * beaconval[beacontype][1 /*knights*/];
+                currval -= arrhitby * beaconval[beacontype][2 /*arrows*/];
+                currval -= arlhitby * beaconval[beacontype][2 /*arrows*/];
+                currval -= ardhitby * beaconval[beacontype][2 /*arrows*/];
+                currval -= aruhitby * beaconval[beacontype][2 /*arrows*/];
+                currval -= hwlhitby * beaconval[beacontype][3 /*walls*/];
+                currval -= vwlhitby * beaconval[beacontype][3 /*walls*/];
+                currval -= dthitby * beaconval[beacontype][4 /*donuts*/];
+
+                if (    (currforcecount <= 0)
+                     || (forcetype == 0)
+                   )
+                {
+                    tempval = currval + sqavail * beaconval[beacontype][0 /*squares*/];
+
+                    if (    (    (tempval > 100)
+                              || (    (tempval > 40)
+                                   && (beacontype == 2)
+                                 )
+                            )
+                         && (tempval > workval)
+                       )
+                    {
+                        workx = x;
+                        worky = y;
+                        workval = tempval;
+                        workbeacon = 1; /*squares*/
+                    }
+                }
+
+                if (    (currforcecount <= 0)
+                     || (forcetype == 1)
+                   )
+                {
+                    tempval = currval + knavail * beaconval[beacontype][1 /*knights*/];
+
+                    if (    (    (tempval > 100)
+                              || (    (tempval > 40)
+                                   && (beacontype == 2)
+                                 )
+                            )
+                         && (tempval > workval)
+                       )
+                    {
+                        workx = x;
+                        worky = y;
+                        workval = tempval;
+                        workbeacon = 2; /*knights*/
+                    }
+                }
+
+                if (    (currforcecount <= 0)
+                     || (forcetype == 2)
+                   )
+                {
+                    tempval = currval + arravail * beaconval[beacontype][2 /*arrows*/];
+
+                    if (    (    (tempval > 100)
+                              || (    (tempval > 40)
+                                   && (beacontype == 2)
+                                 )
+                            )
+                         && (tempval > workval)
+                       )
+                    {
+                        workx = x;
+                        worky = y;
+                        workval = tempval;
+                        workbeacon = 3; /*arrow right*/
+                    }
+                }
+
+                if (    (currforcecount <= 0)
+                     || (forcetype == 2)
+                   )
+                {
+                    tempval = currval + arlavail * beaconval[beacontype][2 /*arrows*/];
+
+                    if (    (    (tempval > 100)
+                              || (    (tempval > 40)
+                                   && (beacontype == 2)
+                                 )
+                            )
+                         && (tempval > workval)
+                       )
+                    {
+                        workx = x;
+                        worky = y;
+                        workval = tempval;
+                        workbeacon = 4; /*arrow left*/
+                    }
+                }
+
+                if (    (currforcecount <= 0)
+                     || (forcetype == 2)
+                   )
+                {
+                    tempval = currval + ardavail * beaconval[beacontype][2 /*arrows*/];
+
+                    if (    (    (tempval > 100)
+                              || (    (tempval > 40)
+                                   && (beacontype == 2)
+                                 )
+                            )
+                         && (tempval > workval)
+                       )
+                    {
+                        workx = x;
+                        worky = y;
+                        workval = tempval;
+                        workbeacon = 5; /*arrow down*/
+                    }
+                }
+
+                if (    (currforcecount <= 0)
+                     || (forcetype == 2)
+                   )
+                {
+                    tempval = currval + aruavail * beaconval[beacontype][2 /*arrows*/];
+
+                    if (    (    (tempval > 100)
+                              || (    (tempval > 40)
+                                   && (beacontype == 2)
+                                 )
+                            )
+                         && (tempval > workval)
+                       )
+                    {
+                        workx = x;
+                        worky = y;
+                        workval = tempval;
+                        workbeacon = 6; /*arrow up*/
+                    }
+                }
+
+                if (    (currforcecount <= 0)
+                     || (forcetype == 3)
+                   )
+                {
+                    tempval = currval + hwlavail * beaconval[beacontype][3 /*walls*/];
+
+                    if (    (    (tempval > 100)
+                              || (    (tempval > 40)
+                                   && (beacontype == 2)
+                                 )
+                            )
+                         && (tempval > workval)
+                       )
+                    {
+                        workx = x;
+                        worky = y;
+                        workval = tempval;
+                        workbeacon = 7; /*horizontal wall*/
+                    }
+                }
+
+                if (    (currforcecount <= 0)
+                     || (forcetype == 3)
+                   )
+                {
+                    tempval = currval + vwlavail * beaconval[beacontype][3 /*walls*/];
+
+                    if (    (    (tempval > 100)
+                              || (    (tempval > 40)
+                                   && (beacontype == 2)
+                                 )
+                            )
+                         && (tempval > workval)
+                       )
+                    {
+                        workx = x;
+                        worky = y;
+                        workval = tempval;
+                        workbeacon = 8; /*vertical wall*/
+                    }
+                }
+
+                if (    (currforcecount <= 0)
+                     || (forcetype == 4)
+                   )
+                {
+                    tempval = currval + dtavail * beaconval[beacontype][4 /*donuts*/];
+
+                    if (    (    (tempval > 100)
+                              || (    (tempval > 40)
+                                   && (beacontype == 2)
+                                 )
+                            )
+                         && (tempval > workval)
+                       )
+                    {
+                        workx = x;
+                        worky = y;
+                        workval = tempval;
+                        workbeacon = 9; /*donut*/
+                    }
+                }
+            }
+        }
+
+        if (workval > 0)
+        {
+            done = false;
+
+            if (    (workmap[workx][worky] != 0)
+                 || (workbeacon == 0)
+               )
+            {
+                printf ("ERROR! Bad logic!!!\n");
+            }
+            workmap[workx][worky] = workbeacon;
+            currforcecount--;
+        }
+    }
+    mapbasevalue = 0;
+    mapfinalvalue = 0;
+
+    for (x = 0; x < MAX_ROW; x++)
+    {
+        for (y = 0; y < MAX_COL; y++)
+        {
+            currval = 100; /* current square is worth 100 base before adding beacon modifiers */
+
+            if (workmap[x][y] >= 0)
+            {
+                mapbasevalue += currval;
+            }
+
+            if (workmap[x][y] == 0) /* 0=empty square, usable and without a beacon on it. */
+            {
+                sqhitby = sqavail = knhitby = knavail = arlhitby = arlavail = 0;
+                arrhitby = arravail = aruhitby = aruavail = ardhitby = ardavail = 0;
+                hwlhitby = hwlavail = vwlhitby = vwlavail = dthitby = dtavail = 0;
+
+                CalcSqValues (&sqhitby, &sqavail, x, y);
+                CalcKnValues (&knhitby, &knavail, x, y);
+                CalcArValues (&arrhitby, &arravail, &arlhitby, &arlavail,
+                              &ardhitby, &ardavail, &aruhitby, &aruavail, x, y);
+                CalcWlValues (&hwlhitby, &hwlavail, &vwlhitby, &vwlavail, x, y);
+                CalcDtValues (&dthitby, &dtavail, x, y);
+
+                currval += sqhitby * beaconval[beacontype][0 /*squares*/];
+                currval += knhitby * beaconval[beacontype][1 /*knights*/];
+                currval += arrhitby * beaconval[beacontype][2 /*arrows*/];
+                currval += arlhitby * beaconval[beacontype][2 /*arrows*/];
+                currval += ardhitby * beaconval[beacontype][2 /*arrows*/];
+                currval += aruhitby * beaconval[beacontype][2 /*arrows*/];
+                currval += hwlhitby * beaconval[beacontype][3 /*walls*/];
+                currval += vwlhitby * beaconval[beacontype][3 /*walls*/];
+                currval += dthitby * beaconval[beacontype][4 /*donuts*/];
+
+                mapfinalvalue += currval;
+            }
+        }
+    }
+
+    if (bDebug)
+    {
+        cout << "  MapValue: " << mapfinalvalue << "\n";
+    }
+
+    if (mapfinalvalue > iBestVal)
+    {
+        iBestVal = mapfinalvalue;
+        CopyMap (workmap, bestmap);
+    }
+    return 0;
+}
+
+void DebugCreateNew ()
+{
+    char sData[360] = {0},
+         sFile[80];
+    int iTest = 0;
+
+    sprintf (sFile, "debugtest.txt");
+
+    ofstream Data(sFile);
+
+    Data << "Here is the new version of the file" << endl;
+    Data << "This should be the second line." << endl << "1" << endl;
+    return;
+}
+
+bool DebugTestGrounds ()
+{
+    bool bRetVal = true;
+
+    char sData[360] = {0},
+         sFile[80];
+    int iTest = 0;
+
+    sprintf (sFile, ".\\debugtest.txt");
+
+    ifstream Data(sFile);
+
+    while (iTest == 0)
+    {
+        Data >> sData;
+        iTest = MakeNumber (sData);
+        cout << sData << endl;
+    }
+
+//    system ("del debugtest.txt /q");
+
+    DebugCreateNew();
+
+    bRetVal = false;
+
+
+    return bRetVal;
+}
+
+void WriteOneMap (ofstream& Data, int mapnum, int beacontype, int score, int map[MAX_ROW][MAX_COL], int beacons)
+{
+    int x, y;
+
+    Data << endl << mapnum;
+    
+    switch (mapnum)
+    {
+        case 1:
+        {
+            Data << "-Tutorial" << endl;
+            break;
+        }
+        case 2:
+        {
+            Data << "-Flesh" << endl;
+            break;
+        }
+        case 3:
+        {
+            Data << "-Tronne" << endl;
+            break;
+        }
+        case 4:
+        {
+            Data << "-Candyland" << endl;
+            break;
+        }
+        default:
+        {
+            Data << "-unknown_map" << endl;
+            break;
+        }
+    }
+    Data << beacontype;
+
+    switch (beacontype)
+    {
+        case 0:
+        {
+            Data << "-Speed" << endl;
+            break;
+        }
+        case 1:
+        {
+            Data << "-Production" << endl;
+            break;
+        }
+        case 2:
+        {
+            Data << "-Efficiency" << endl;
+            break;
+        }
+        case 3:
+        {
+            Data << "-Speed/Production_mix" << endl;
+            break;
+        }
+        default:
+        {
+            Data << "-unknown" << endl;
+            break;
+        }
+    }
+
+    Data << beacons;
+
+    switch (beacons)
+    {
+        case 0:
+        {
+            Data << "-Boxes_only" << endl;
+            break;
+        }
+        case 1:
+        {
+            Data << "-Up_to_Knights" << endl;
+            break;
+        }
+        case 2:
+        {
+            Data << "-Up_to_Arrows" << endl;
+            break;
+        }
+        case 3:
+        {
+            Data << "-Up_to_Walls" << endl;
+            break;
+        }
+        case 4:
+        {
+            Data << "-Up_to_Donuts" << endl;
+            break;
+        }
+        default:
+        {
+            Data << "-unknown" << endl;
+            break;
+        }
+    }
+    Data << score << "-Score" << endl;
+
+    for (x = 0; x < MAX_ROW; x++)
+    {
+        for (y = 0; y < MAX_COL; y++)
+        {
+            Data << BeaconNum2Disp (map[x][y]);
+        }
+        Data << endl;
+    }
+    Data << endl;
+
+}
+
+void LoadBestMaps ()
+{
+    bestmaps *temp = maplist, *temp2 = 0;
+    char sData[360] = {0},
+         sFile[80];
+    int i, x, y, iData;
+
+    sprintf (sFile, ".\\bestmaps.txt");
+
+    ifstream Data(sFile);
+
+    while (temp)
+    {
+        temp = maplist->next;
+        free (maplist);
+        maplist = temp;
+    }
+    i = 0;
+    Data >> sData;
+    iTotalMaps = MakeNumber (sData);
+
+    while (i < iTotalMaps)
+    {
+        i++;
+        temp = (bestmaps *) calloc (1, sizeof (bestmaps) );
+
+        if (!temp)
+        {
+            exit (0);
+        }
+
+        Data >> sData;
+        iData = MakeNumber (sData);
+        temp->mapnum = iData;
+
+        Data >> sData;
+        iData = MakeNumber (sData);
+        temp->beacontype = iData;
+
+        Data >> sData;
+        iData = MakeNumber (sData);
+        temp->maxbeacon = iData;
+
+        temp->mapID = (temp->mapnum * 100) + (temp->beacontype * 10) + temp->maxbeacon;
+
+        Data >> sData;
+        iData = MakeNumber (sData);
+        temp->score = iData;
+
+        for (x = 0; x < MAX_ROW; x++)
+        {
+            Data >> sData;
+
+            for (y = 0; y < MAX_COL; y++)
+            {
+                iData = BeaconDisp2Num (sData[y]);
+                temp->map[x][y] = iData;
+            }
+        }
+
+        if (!maplist)
+        {
+            maplist = temp;
+        }
+        else
+        {
+            temp2 = maplist;
+
+            while (    temp2->next
+                    && (    (temp->map > temp2->next->map)
+                         || (    (temp->map == temp2->next->map)
+                              && (temp->beacontype > temp2->next->beacontype)
+                            )
+                       )
+                  )
+            {
+                temp2 = temp2->next;
+            }
+
+            if (    !temp2
+                 || (temp->map != temp2->next->map)
+                 || (temp->beacontype != temp2->next->beacontype)
+               )
+            {
+                temp->next = temp2->next;
+                temp2->next = temp;
+            }
+            else
+            {
+                temp->next = temp2->next->next;
+                free (temp2->next);
+                temp2->next = temp;
+            }
+        }
+    }
+    Data.close();
+}
+
+void SaveBestMaps ()
+{
+    bestmaps *temp = maplist, *temp2 = 0;
+    char sData[360] = {0},
+         sFile[80];
+
+    sprintf (sFile, ".\\bestmaps.txt");
+
+    ofstream Data(sFile);
+
+    iTotalMaps = 0;
+
+    while (temp)
+    {
+        iTotalMaps++;
+        temp = temp->next;
+    }
+
+    Data << iTotalMaps << "-Total_number_of_maps_recorded" << endl;
+
+    temp = maplist;
+
+    while (temp)
+    {
+        WriteOneMap (Data, temp->mapnum, temp->beacontype, temp->score, temp->map, temp->maxbeacon);
+        temp = temp->next;
+    }
+    Data.close ();
+    return;
+}
+
+void Cleanup ()
+{
+    bestmaps *temp;
+
+    while (maplist)
+    {
+        temp = maplist->next;
+        free (maplist);
+        maplist = temp;
+    }
+}
+
+/* This originally was just to load the map. It now includes other setup functionality as well. */
+void SetWhichToCheck (int maps, int options)
+{
+    char sData[360] = {0},
+         sFile[80];
+    bool bRetVal = false;
+    int iVal = 0, x = 0, y = 0;
+
+    sprintf (sFile, ".\\tutorial.txt");
+
+    if (maps == 2)
+    {
+        sprintf (sFile, ".\\flesh.txt");
+    }
+
+    if (maps == 3)
+    {
+        sprintf (sFile, ".\\tronne.txt");
+    }
+
+    if (maps == 4)
+    {
+        sprintf (sFile, ".\\candyland.txt");
+    }
+
+    ifstream Data(sFile);
+
+    Data >> sData;
+
+    for (x = 0; x < 17; x++)
+    {
+        for (y = 0; y < 20; y++)
+        {
+            if (sData[y] == '1') // 1 = open to place
+            {
+                basemap[x][y] = 1;
+            }
+            else if(sData[y] == '2') // 2 = usable, but currently blocked
+            {
+                basemap[x][y] = 2;
+            }
+            else
+            {
+                basemap[x][y] = 0; // 0 = unusable square
+            }
+        }
+        Data >> sData;
+    }
+
+    for (x = 0; x < (MAX_ROW * MAX_COL); x++)
+    {
+        searchorder[x] = x;
+    }
+
+    for (x = 0; x < MAX_ROW; x++)
+    {
+        for (y = 0; y < MAX_COL; y++)
+        {
+            switch (basemap[x][y])
+            {
+                case 1:
+                {
+                    baseworkmap[x][y] = 0;
+                    break;
+                }
+                case 2:
+                {
+                    if (options == 1)
+                    {
+                        baseworkmap[x][y] = 0;
+                    }
+                    else
+                    {
+                        baseworkmap[x][y] = -1;
+                    }
+                    break;
+                }
+                default:
+                {
+                    baseworkmap[x][y] = -1;
+                    break;
+                }
+            }
+        }
+    } // initialize base working map,
+
+    beaconxref[1] = 0; /* Boxes */
+    beaconxref[2] = 1; /* Knights */
+    beaconxref[3] = 2; /* Arrows */
+    beaconxref[4] = 2; /* Arrows */
+    beaconxref[5] = 2; /* Arrows */
+    beaconxref[6] = 2; /* Arrows */
+    beaconxref[7] = 3; /* Walls */
+    beaconxref[8] = 3; /* Walls */
+    beaconxref[9] = 4; /* Donuts */
+
+    return;
+}
+
+bool NewBestMap (int map, int beacontype, int beacons)
+{
+    bestmaps *temp = 0, *temp2 = 0;
+    bool bRetVal = false;
+    int iMapID;
+
+    iMapID = (map * 100) + (beacontype * 10) + beacons;
+
+    if (!maplist)
+    {
+        LoadBestMaps ();
+
+        if (!maplist)
+        {
+            maplist = (bestmaps*) calloc (1, sizeof (bestmaps) );
+
+            if (!maplist)
+            {
+                exit (0);
+            }
+            maplist->mapnum = map;
+            maplist->beacontype = beacontype;
+            maplist->maxbeacon = beacons;
+            maplist->score = iBestVal;
+            maplist->mapID = (map * 100) + (beacontype * 10) + beacons;
+            memcpy (maplist->map, bestmap, iTotalArea * sizeof (int) );
+            bRetVal = true;
+        }
+    }
+
+    temp = maplist;
+
+    if (    temp
+         && (iMapID < temp->mapID)
+       ) /* Is new map lower than first recorded map? */
+    {
+        temp2 = (bestmaps*) calloc (1, sizeof (bestmaps) );
+
+        if (!temp2)
+        {
+            exit (0);
+        }
+        temp2->mapnum = map;
+        temp2->beacontype = beacontype;
+        temp2->maxbeacon = beacons;
+        temp2->mapID = iMapID;
+        temp2->score = iBestVal;
+        memcpy (temp2->map, bestmap, iTotalArea * sizeof (int) );
+        temp2->next = maplist;
+        maplist = temp2;
+        temp = 0;
+        bRetVal = true;
+    }
+
+    while (temp)
+    {
+        if (iMapID == temp->mapID)
+        {
+            /* Map exists. Need to see if new result is better. */
+            if (iBestVal > temp->score)
+            {
+                temp->score = iBestVal;
+                memcpy (temp->map, bestmap, iTotalArea * sizeof (int) );
+                temp = 0;
+                bRetVal = true;
+            }
+            temp = 0;
+        }
+        else if (    (temp->next)
+                  && (iMapID >= temp->next->mapID)
+                )
+        {
+            temp = temp->next;
+        }
+        else
+        {
+            temp2 = (bestmaps*) calloc (1, sizeof (bestmaps) );
+
+            if (!temp2)
+            {
+                exit (0);
+            }
+            temp2->mapnum = map;
+            temp2->beacontype = beacontype;
+            temp2->maxbeacon = beacons;
+            temp2->mapID = iMapID;
+            temp2->score = iBestVal;
+            memcpy (temp2->map, bestmap, iTotalArea * sizeof (int) );
+            temp2->next = temp->next;
+            temp->next = temp2;
+            temp = 0;
+            bRetVal = true;
+        }
+    }
+
+    return bRetVal;
+}
 

--- a/helper.cpp
+++ b/helper.cpp
@@ -1,0 +1,169 @@
+#include "stdafx.h"
+#include <string.h>
+#include "Accessories.h"
+
+
+int BeaconDisp2Num (char c)
+{
+    int iData;
+
+    switch (c)
+    {
+        case '~':
+        {
+            iData = -1;
+            break;
+        }
+        case '.':
+        {
+            iData = 0;
+            break;
+        }
+        case '#':
+        {
+            iData = 1;
+            break;
+        }
+        case 'K':
+        {
+            iData = 2;
+            break;
+        }
+        case '>':
+        {
+            iData = 3;
+            break;
+        }
+        case '<':
+        {
+            iData = 4;
+            break;
+        }
+        case 'v':
+        {
+            iData = 5;
+            break;
+        }
+        case '^':
+        {
+            iData = 6;
+            break;
+        }
+        case '-':
+        {
+            iData = 7;
+            break;
+        }
+        case '|':
+        {
+            iData = 8;
+            break;
+        }
+        case 'O':
+        {
+            iData = 9;
+            break;
+        }
+        default:
+        {
+            iData = -1;
+            break;
+        }
+    }
+    return iData;
+}
+
+char BeaconNum2Disp (int i)
+{
+    char c;
+
+    switch (i)
+    {
+        case -1:
+        {
+            c = '~';
+            break;
+        }
+        case 0:
+        {
+            c = '.';
+            break;
+        }
+        case 1:
+        {
+            c = '#';
+            break;
+        }
+        case 2:
+        {
+            c = 'K';
+            break;
+        }
+        case 3:
+        {
+            c = '>';
+            break;
+        }
+        case 4:
+        {
+            c = '<';
+            break;
+        }
+        case 5:
+        {
+            c = 'v';
+            break;
+        }
+        case 6:
+        {
+            c = '^';
+            break;
+        }
+        case 7:
+        {
+            c = '-';
+            break;
+        }
+        case 8:
+        {
+            c = '|';
+            break;
+        }
+        case 9:
+        {
+            c = 'O';
+            break;
+        }
+        default:
+        {
+            c = 'X';
+            break;
+        }
+    }
+    return c;
+}
+
+int MakeNumber (char *sData)
+{
+    int x = 0, iRetVal =0;
+
+    while (    (sData[x] >= '0')
+            && (sData[x] <= '9')
+          )
+    {
+        iRetVal += sData[x] - 48;
+        iRetVal *= 10;
+        x++;
+
+        if (iRetVal > 1000000000)
+        {
+            sData[0] = 0;
+            x = 0;
+            iRetVal = 0;
+        }
+    }
+    iRetVal /= 10;
+
+    return iRetVal;
+}
+


### PR DESCRIPTION
Program will create/update bestmaps.txt file with the best found map that run, if it is better than the best map of the same type in bestmaps.txt.

Maps are saved by map (flesh, Tronne, etc), then by beacon type (speed, prod or eff), and finally by max beacon shape allowed (box to donuts).

The functionality ignores the option for blocked tiles. If the map is better, it saves it. So make a backup of bestmaps.txt if you have some results with blocked squares you want to preserve while testing fully unlocked maps.